### PR TITLE
#6 fix arithmetic constructor's enabler template argument

### DIFF
--- a/include/cpp-json/value.h
+++ b/include/cpp-json/value.h
@@ -48,7 +48,7 @@ public:
 	value(const char *s);
 	value(const object &o);
 	value(std::string s);
-	template <class T, typename std::enable_if<std::is_arithmetic<T>::value>::type = 0>
+	template <class T, typename = std::enable_if<std::is_arithmetic<T>::value>::type>
 	value(T n);
 	value(const std::nullptr_t &);
 

--- a/include/cpp-json/value.tcc
+++ b/include/cpp-json/value.tcc
@@ -73,7 +73,7 @@ inline value::value(std::string s) : type_(type_string) {
 //------------------------------------------------------------------------------
 // Name: value
 //------------------------------------------------------------------------------
-template <class T, typename std::enable_if<std::is_arithmetic<T>::value>::type>
+template <class T, typename>
 value::value(T n) : type_(type_number) {
     new (&value_) std::string(std::to_string(n));
 }


### PR DESCRIPTION
The way you changed the enable_if on the second template argument isn't an SFINAE expression anymore, which results in integer literals with values 0, 1 being implicitly converted.

`json::object{{"key", 1}}` leads to warning - from VC++2015: warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning).